### PR TITLE
First draft: validate watch files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "log",
+ "notify",
  "regex",
  "style-generator-core",
  "tokio",

--- a/style-validate/Cargo.toml
+++ b/style-validate/Cargo.toml
@@ -13,6 +13,7 @@ grep-matcher = "0.1.5"
 grep-regex = "0.1.9"
 grep-searcher = "0.1.8"
 log = "0.4.14"
+notify = "5.0.0-pre.11"
 regex = "1.5.4"
 style-generator-core = {path = "../style-generator-core"}
 tokio = {version = "1.9.0", features = ["full"]}


### PR DESCRIPTION
Closes https://github.com/scoville/tailwind-generator/issues/36


Revalidates project on file change. Notice that since `notify` (the library we use for watching/executing) doesn't support globs the user must provide the path twice (also, they could be different and in the future I think it would make sense to accept a list of `-w` or to have it in a config file (https://github.com/scoville/tailwind-generator/issues/35)).

Seems to work well and the dev experience even on large projects (~5000 files of ~650 lines each) is smooth.

Some things to improve:
- Code (it's a bit rough and basically copied from the generate command)
- Ownership is not good (we send arc here and there, clone them when not needed, watch path is not computed when it should etc...)
- Not exit on file rename (except the file is the css file), just keep going
- Better error handling